### PR TITLE
parser.y수정 

### DIFF
--- a/ReportError.c
+++ b/ReportError.c
@@ -36,6 +36,12 @@ void reportError(ERRORtypes err) {
 	case nobracket:
 		printf("Parser Error: Missing bracket\n");
 		break;
+	case nobrace:
+		printf("Parser Error: Missing brace\n");
+		break;
+	case nosqubracket:
+		printf("Parser Error: Missing square bracket\n");
+		break;
 	case nocomma:
 		printf("Parser Error: Missing comma\n");
 		break;

--- a/glob.h
+++ b/glob.h
@@ -7,7 +7,7 @@
 #define STsize 1000	//size of string table
 #define HTsize 100	//size of hash table
 
-enum errorTypes { ILLICHAR, ILLIDENT, wrong_st, wrong_param, wrong_funcdef, wrong_def, nosemi, nobracket, nocomma}; //parse error 추가해야함
+enum errorTypes { ILLICHAR, ILLIDENT, wrong_st, wrong_param, wrong_funcdef, wrong_def, nosemi, nobracket, nobrace, nosqubracket, nocomma}; //parse error 추가해야함
 typedef enum errorTypes ERRORtypes;
 //identifier type
 enum id_type { parse_error, void_function, int_function, float_function, void_scalar, int_scalar, float_scalar, void_array, int_array, float_array };

--- a/parser.y
+++ b/parser.y
@@ -35,7 +35,7 @@ external_dcl	: function_def
 			reportError(wrong_st); /* error - wrong statement */
 		}
 		| temp_char { yyerrok; reportError(wrong_st); }
-		| temp_close { yyerrok; reportError(nobracket); }
+		| temp_close 
 		| TSEMI
 		;
 temp_char	: TADDASSIGN
@@ -64,9 +64,9 @@ temp_char	: TADDASSIGN
 		| TMINUS
 		| TLESS
 		;
-temp_close	: TBRCLOSE
-		| TCURLCLOSE
-		| TSQUCLOSE
+temp_close	: TBRCLOSE { yyerrok; reportError(nobracket); }
+		| TCURLCLOSE { yyerrok; reportError(nobrace); }
+		| TSQUCLOSE { yyerrok; reportError(nosqubracket); }
 		;
 function_def	: function_header compound_st
 		| function_header TSEMI
@@ -143,7 +143,7 @@ compound_st	: TCURLOPEN opt_dcl_list opt_stat_list TCURLCLOSE
 		| TCURLOPEN opt_dcl_list opt_stat_list error
 		{
 			yyerrok;
-			reportError(nobracket);
+			reportError(nobrace);
 		}
 		;
 opt_dcl_list	: declaration_list
@@ -202,7 +202,7 @@ declarator	: TIDENT
 		| TIDENT TSQUOPEN opt_number error
 		{
 			yyerrok;
-			reportError(nobracket);
+			reportError(nosqubracket);
 		}
 		;
 opt_number	: TNUMBER
@@ -312,7 +312,7 @@ postfix_exp	: primary_exp
 		| postfix_exp TSQUOPEN expression error
 		{
 			yyerrok;
-			reportError(nobracket);
+			reportError(nosqubracket);
 		}
 		| postfix_exp TBROPEN opt_actual_param TBRCLOSE
 		| postfix_exp TBROPEN opt_actual_param error

--- a/parser.y
+++ b/parser.y
@@ -29,21 +29,15 @@ translation_unit	: external_dcl
 external_dcl	: function_def
 		| declaration
 		| TIDENT TSEMI
-		| TIDENT error
+		| error
 		{
 			yyerrok;
 			reportError(wrong_st); /* error - wrong statement */
 		}
-		| error TIDENT
-		{
-			yyerrok;
-			reportError(wrong_st); /* error - wrong statement */
-		}
-//		| error error { yyerrok; printf("f**kin\n"); }
 		| temp_char { yyerrok; reportError(wrong_st); }
 		| temp_close { yyerrok; reportError(nobracket); }
+		| TSEMI
 		;
-//temp_char	: TIDENT
 temp_char	: TADDASSIGN
 		| TSUBASSIGN
 		| TMULASSIGN
@@ -69,7 +63,6 @@ temp_char	: TADDASSIGN
 		| TNOT
 		| TMINUS
 		| TLESS
-//		| TSEMI
 		;
 temp_close	: TBRCLOSE
 		| TCURLCLOSE
@@ -140,11 +133,10 @@ formal_param_list	: param_dcl
 			}
 			;
 param_dcl	: dcl_spec declarator
-//		| dcl_spec error
-		| dcl_spec error TSEMI
+		| dcl_spec error 
 		{
 			yyerrok;
-			reportError(wrong_def);
+			reportError(wrong_param);
 		}
 		;
 compound_st	: TCURLOPEN opt_dcl_list opt_stat_list TCURLCLOSE
@@ -175,11 +167,10 @@ declaration	: dcl_spec init_dcl_list TSEMI
 			vtype=0;
 			reportError(nosemi);
 		}
-		| dcl_spec error
+		| dcl_spec error TSEMI
 		{
 			yyerrok;
 			reportError(wrong_def);
-			//reportError(wrong_param);
 		}
 		;
 init_dcl_list	: init_declarator
@@ -244,29 +235,29 @@ opt_expression	: expression
 		;
 if_st	: TIF TBROPEN expression TBRCLOSE statement %prec LOWER_THAN_ELSE
 	| TIF TBROPEN expression TBRCLOSE statement TELSE statement
+	| TIF TBROPEN expression error
+	{
+		yyerrok;
+		reportError(nobracket);
+	}	
 	| TIF error
 	{
 		yyerrok;
 		printf("if");
 		reportError(nobracket);
 	}
-/*	| TIF TBROPEN expression error
-	{
-		yyerrok;
-		reportError(nobracket);
-	}*/
 	;
 while_st	: TWHILE TBROPEN expression TBRCLOSE statement
+		| TWHILE TBROPEN expression error
+		{
+			yyerrok;
+			reportError(nobracket);
+		}
 		| TWHILE error
 		{
 			yyerrok;
 			reportError(nobracket);
 		}
-/*		| TWHILE TBROPEN expression error
-		{
-			yyerrok;
-			reportError(nobracket);
-		}*/
 		;
 return_st	: TRETURN opt_expression TSEMI
 		| TRETURN opt_expression error


### PR DESCRIPTION
### ★ 코드 확인 부탁드려여,, 🥺 
* 변수 선언 에러 쪽 수정 
    * 파라미터 dcl 이랑 변수 dcl 쪽이 서로 바뀐 것 같아서 수정했음니다

* 세미콜론"만" 나오면 아무것도 안하고 넘기기
* TIDENT error / error TIDENT --> error 분리
    * error 전후로 IDENT토큰이 같이 묶여서 잘리는 경우가 신경쓰여서 error 만 따로 뺐습니다... ㅠㅠ
    * 제가 만든 함수 내에 있는 에러에서는 잘 작동하는거같아서 이렇게 했는데 에러 있으면 다시 tident error/ error tident로 바꿔주새요